### PR TITLE
Setup company model

### DIFF
--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,0 +1,2 @@
+class Company < ApplicationRecord
+end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,2 +1,10 @@
 class Company < ApplicationRecord
+    enum plan_level: [ :legacy, :custom, :basic, :plus, :growth, :enterprise ]
+
+    before_create :set_default_plan
+
+    private
+        def set_default_plan
+            self.plan_level ||= 2
+        end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,4 +1,6 @@
 class Company < ApplicationRecord
+    validates :name, presence: true, length: { in: 3..254 }
+
     enum plan_level: [ :legacy, :custom, :basic, :plus, :growth, :enterprise ]
 
     before_create :set_default_plan, :set_trial_status

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,10 +1,14 @@
 class Company < ApplicationRecord
     enum plan_level: [ :legacy, :custom, :basic, :plus, :growth, :enterprise ]
 
-    before_create :set_default_plan
+    before_create :set_default_plan, :set_trial_status
 
     private
         def set_default_plan
             self.plan_level ||= 2
+        end
+
+        def set_trial_status
+            self.trial_status = 30.days.from_now.beginning_of_day
         end
 end

--- a/db/migrate/20180406021531_create_companies.rb
+++ b/db/migrate/20180406021531_create_companies.rb
@@ -1,0 +1,11 @@
+class CreateCompanies < ActiveRecord::Migration[5.1]
+  def change
+    create_table :companies do |t|
+      t.string :name
+      t.datetime :trial_status
+      t.string :plan_level
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180406021531_create_companies.rb
+++ b/db/migrate/20180406021531_create_companies.rb
@@ -3,7 +3,7 @@ class CreateCompanies < ActiveRecord::Migration[5.1]
     create_table :companies do |t|
       t.string :name
       t.datetime :trial_status
-      t.string :plan_level
+      t.integer :plan_level
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,23 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20180406021531) do
+
+  create_table "companies", force: :cascade do |t|
+    t.string "name"
+    t.datetime "trial_status"
+    t.integer "plan_level"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/companies.yml
+++ b/test/fixtures/companies.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  trial_status: 2018-04-05 22:15:31
+  plan_level: MyString
+
+two:
+  name: MyString
+  trial_status: 2018-04-05 22:15:31
+  plan_level: MyString

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CompanyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## In this PR:

- Create a `Company` data model
- Establish an enum attribute to limit `plan_level` options to 5 predefined levels and assign a default plan if one isn't specified
- When a company is created, the `trial_status` expiration date is automatically set for midnight 30 days from the creation date
- Validates the presence and length of the `name` attribute. Length must be more than 2 characters and less than 255 characters.