### PR TITLE
Return modern plan companies

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -6,4 +6,8 @@ class CompaniesController < ApplicationController
   def alphabetize
     render json: { data: Company.alphabetize }
   end
+
+  def with_modern_plan
+    render json: { data: Company.modern }
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -8,6 +8,7 @@ class Company < ApplicationRecord
     before_create :set_default_plan, :set_trial_status
 
     scope :alphabetize, -> { order(name: :asc) }
+    scope :modern, -> { where('plan_level != 0 AND plan_level != 1') }
 
     private
         def set_default_plan

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   get 'companies' => 'companies#index'
   namespace :companies do
     get :alphabetize
+    get :with_modern_plan
   end
 end


### PR DESCRIPTION
## In this PR:
- Add a `with_modern_plan` route
- Create a `modern` scope in the Company model
- Create an `with_modern_plan` controller action that returns a JSON object of all companies with a modern plan level (not `legacy` or `custom`)