### PR TITLE
Return not trialing companies

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -10,4 +10,8 @@ class CompaniesController < ApplicationController
   def with_modern_plan
     render json: { data: Company.modern }
   end
+
+  def not_trialing
+    render json: { data: Company.not_trialing }
+  end
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,6 +9,7 @@ class Company < ApplicationRecord
 
     scope :alphabetize, -> { order(name: :asc) }
     scope :modern, -> { where('plan_level != 0 AND plan_level != 1') }
+    scope :not_trialing, -> { where('trial_status < ?', DateTime.now) }
 
     private
         def set_default_plan

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@ Rails.application.routes.draw do
   namespace :companies do
     get :alphabetize
     get :with_modern_plan
+    get :not_trialing
   end
 end


### PR DESCRIPTION
## In this PR:
- Add a `not_trialing` route
- Create a `not_trialing` scope in the Company model
- Create a `not_trialing` controller action that returns a JSON object of all companies who are not currently within their trial period.